### PR TITLE
refactor(designers): add module to read context params implicitly

### DIFF
--- a/lib/interactor/context_reader.rb
+++ b/lib/interactor/context_reader.rb
@@ -1,0 +1,23 @@
+module Interactor
+  # This module allows to define the context params that will be used by the interactor
+  module ContextReader
+    def self.included(base)
+      base.class_eval do
+        extend ClassMethods
+      end
+    end
+
+    # Defines some class methods that will be used by the interactor when the context is read
+    module ClassMethods
+      def context_params(*names)
+        names.each do |name|
+          define_method(name) do
+            raise ArgumentError, "Missing context param #{name}" unless context.respond_to?(name)
+
+            context.public_send(name)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/structuraid_core/designers/footings/centric_isolated.rb
+++ b/lib/structuraid_core/designers/footings/centric_isolated.rb
@@ -6,6 +6,9 @@ module StructuraidCore
       # Runs the design process for a centric isolated footing. The footing is expected to have defined dimensions. The design process will just return the reinforcement disposition and wether it passes or not the design requirements
       class CentricIsolated
         include Interactor::Organizer
+        include Interactor::ContextReader
+
+        context_params :footing, :load_scenario, :soil, :design_code, :steel, :support_type
 
         # @param footing [StructuraidCore::Elements::Footing] The footing to be designed. It needs to have length_1, length_2, height, material defined, and reinforcement without layers
         # @param load_scenario [StructuraidCore::Loads::Scenarios::Footings::CentricIsolated] The load scenario to be considered

--- a/lib/structuraid_core/designers/footings/steps/assign_analysis_direction.rb
+++ b/lib/structuraid_core/designers/footings/steps/assign_analysis_direction.rb
@@ -7,6 +7,9 @@ module StructuraidCore
         # Assigns the direction for the footing analysis. It can be either length_1 or length_2, depending on wether the analysis has run for the first or second time
         class AssignAnalysisDirection
           include Interactor
+          include Interactor::ContextReader
+
+          context_params :analysis_length_1, :analysis_length_2
 
           # @param analysis_length_1 [Boolean optional] Wether the analysis has run for the length_1 section or not
           # @param analysis_length_2 [Boolean optional] Wether the analysis has run for the length_2 section or not
@@ -15,16 +18,6 @@ module StructuraidCore
             return context.analysis_direction = :length_2 if analysis_length_2.nil?
 
             context.fail!(message: 'Analysis has been run for all directions already')
-          end
-
-          private
-
-          def analysis_length_1
-            @analysis_length_1 ||= context.analysis_length_1
-          end
-
-          def analysis_length_2
-            @analysis_length_2 ||= context.analysis_length_2
           end
         end
       end

--- a/lib/structuraid_core/designers/footings/steps/centric_isolated/compute_required_rebar_ratio.rb
+++ b/lib/structuraid_core/designers/footings/steps/centric_isolated/compute_required_rebar_ratio.rb
@@ -8,6 +8,9 @@ module StructuraidCore
           # Runs the structural bending analysis and design for a centric isolated footing, generating the required reinforcement ratio and adding it to the context
           class ComputeRequiredRebarRatio
             include Interactor
+            include Interactor::ContextReader
+
+            context_params :load_scenario, :design_code, :steel, :analysis_direction, :footing
 
             # @param load_scenario [StructuraidCore::Loads::Scenarios::Footings::CentricIsolated] The load scenario to be considered
             # @param design_code [StructuraidCore::DesignCodes] The design code to be used
@@ -63,26 +66,6 @@ module StructuraidCore
 
             def flexural_moment
               @flexural_moment ||= context.analysis_results[:bending_momentum]
-            end
-
-            def steel
-              @steel ||= context.steel
-            end
-
-            def footing
-              @footing ||= context.footing
-            end
-
-            def load_scenario
-              @load_scenario ||= context.load_scenario
-            end
-
-            def analysis_direction
-              @analysis_direction ||= context.analysis_direction
-            end
-
-            def design_code
-              @design_code ||= context.design_code
             end
           end
         end

--- a/lib/structuraid_core/designers/footings/steps/centric_isolated/set_reinforcement_layers_coordinates_to_footing.rb
+++ b/lib/structuraid_core/designers/footings/steps/centric_isolated/set_reinforcement_layers_coordinates_to_footing.rb
@@ -9,8 +9,11 @@ module StructuraidCore
           # Sets the reinforcement layers coordinates to the footing's coordinates system
           class SetReinforcementLayersCoordinatesToFooting
             include Interactor
+            include Interactor::ContextReader
 
             POSSIBLE_SECTIONS = %i[length_1 length_2].freeze
+
+            context_params :footing, :analysis_direction
 
             # @param footing [StructuraidCore::Elements::Footing] The footing to be designed
             # @param analysis_direction [Symbol] The direction for which the analysis has to be run. Should be either :length_1 or :length2
@@ -79,14 +82,6 @@ module StructuraidCore
                 ],
                 label: 'reinforcement_layer_end_location_length_2_bottom'
               )
-            end
-
-            def footing
-              @footing ||= context.footing
-            end
-
-            def analysis_direction
-              @analysis_direction ||= context.analysis_direction
             end
 
             def secondary_analysis_direction

--- a/lib/structuraid_core/designers/footings/steps/check_bearing_capacity.rb
+++ b/lib/structuraid_core/designers/footings/steps/check_bearing_capacity.rb
@@ -7,6 +7,9 @@ module StructuraidCore
         # Checks if the bearing capacity of the soil is not being exceeded by the footing and its transmitting load
         class CheckBearingCapacity
           include Interactor
+          include Interactor::ContextReader
+
+          context_params :footing, :load_scenario, :soil
 
           # @param footing [StructuraidCore::Elements::Footing] The footing to be designed
           # @param load_scenario [StructuraidCore::Loads::Scenarios::] The load scenario to be considered
@@ -29,15 +32,7 @@ module StructuraidCore
           end
 
           def bearing_capacity
-            @bearing_capacity ||= context.soil.bearing_capacity
-          end
-
-          def load_scenario
-            @load_scenario ||= context.load_scenario
-          end
-
-          def footing
-            @footing ||= context.footing
+            @bearing_capacity ||= soil.bearing_capacity
           end
         end
       end

--- a/lib/structuraid_core/designers/footings/steps/check_min_height.rb
+++ b/lib/structuraid_core/designers/footings/steps/check_min_height.rb
@@ -7,6 +7,7 @@ module StructuraidCore
         # Checks if footing's height is greater at least the minimum required height
         class CheckMinHeight
           include Interactor
+          include Interactor::ContextReader
 
           # @param footing [StructuraidCore::Elements::Footing] The footing to be designed
           # @param support_type [Symbol or String] The support type: :over_soil or :over_piles

--- a/lib/structuraid_core/designers/footings/steps/resolve_design_code.rb
+++ b/lib/structuraid_core/designers/footings/steps/resolve_design_code.rb
@@ -7,10 +7,13 @@ module StructuraidCore
         # Resolves the design code namespace to be used
         class ResolveDesignCode
           include Interactor
+          include Interactor::ContextReader
+
+          context_params :design_code
 
           # @param design_code [Symbol or String] The design code to be used
           def call
-            context.design_code = DesignCodes::Resolver.use(context.design_code)
+            context.design_code = DesignCodes::Resolver.use(design_code)
           rescue Errors::DesignCodes::UnknownDesignCodeError => e
             context.fail!(message: e.message)
           end


### PR DESCRIPTION
Closes #92 

A small monkey patch is added to the Interactor module to be able to set getter methods for specific params in the context, and validate they are present when the interactor is called. This should enhance the readability of interactor classes and should enhance cohesion